### PR TITLE
Fix issue 56

### DIFF
--- a/lib/framework.js
+++ b/lib/framework.js
@@ -233,7 +233,9 @@ var initSystemjs = function(config) {
   	}
     });
     
-    config.files.unshift(filesToInclude);
+	filesToInclude.reverse().forEach(function(file) {
+		config.files.unshift(file);
+	});
   }
 
   // Adds karma-systemjs adapter.js to end of config.files

--- a/lib/framework.js
+++ b/lib/framework.js
@@ -233,9 +233,9 @@ var initSystemjs = function(config) {
   	}
     });
     
-	filesToInclude.reverse().forEach(function(file) {
-		config.files.unshift(file);
-	});
+    filesToInclude.reverse().forEach(function(file) {
+        config.files.unshift(file);
+    });
   }
 
   // Adds karma-systemjs adapter.js to end of config.files


### PR DESCRIPTION
This fixes the behaviour of the includeFiles configuration property. Previously the array of files was unshifted in the config.files, but now the actual items in the array are unshifted (and in reverse order to maintain the includeFiles order).
